### PR TITLE
Fix help tip for main menu navigation

### DIFF
--- a/bot-code/main.py
+++ b/bot-code/main.py
@@ -47,7 +47,7 @@ def main():
     while True:
 
         cmd = input(
-            "\nEnter a command (or 'help' (3) for available commands): ").strip().lower()
+            "\nEnter a command (or 'help' (4) for available commands): ").strip().lower()
 
         if not cmd:
             console.print("Please enter a command from the list of available commands.",

--- a/main.py
+++ b/main.py
@@ -46,7 +46,7 @@ def main():
     while True:
 
         cmd = input(
-            "\nEnter a command (or 'help' (3) for available commands): ").strip().lower()
+            "\nEnter a command (or 'help' (4) for available commands): ").strip().lower()
 
         if not cmd:
             console.print("Please enter a command from the list of available commands.",


### PR DESCRIPTION
В нас через додану раніше фічу vnotes у головному меню не вірно відображається підказка для користувача гарячої клавіши допомоги (help).
Виправив, щоб підказка відповідала саме опції help.